### PR TITLE
Adding support for firefox in idleTimer gallery module

### DIFF
--- a/src/gallery-idletimer/js/idletimer.js
+++ b/src/gallery-idletimer/js/idletimer.js
@@ -36,7 +36,7 @@ function handleUserEvent(event){
     if (enabled){
     
         if (/visibilitychange/.test(event.type)){
-            toggleIdleState(doc.hidden || doc.msHidden || doc.webkitHidden);
+            toggleIdleState(doc.hidden || doc.msHidden || doc.webkitHidden || doc.mozHIdden);
         } else {
             //if it's idle, that means the user is no longer idle
             if (idle){
@@ -133,6 +133,7 @@ Y.IdleTimer = {
         //need to add the old-fashioned way
         doc.addEventListener("msvisibilitychange", handleUserEvent, false)
         doc.addEventListener("webkitvisibilitychange", handleUserEvent, false)
+        doc.addEventListener("mozvisibilitychange", handleUserEvent, false)
         
         //set a timeout to toggle state
         tId = setTimeout(toggleIdleState, timeout);
@@ -159,6 +160,7 @@ Y.IdleTimer = {
 
         doc.removeEventListener("msvisibilitychange", handleUserEvent, false)
         doc.removeEventListener("webkitvisibilitychange", handleUserEvent, false)
+        doc.removeEventListener("mozvisibilitychange", handleUserEvent, false)
       
     }
 


### PR DESCRIPTION
As per https://developer.mozilla.org/en/DOM/Using_the_Page_Visibility_API now mozilla supports mozHidden, mozvisibilitychange from Firefox 10

In idleTimer we had support only for webkit, ms.
