### PR TITLE
Fixing the After Scroll Event in Gallery-carousel

### DIFF
--- a/src/gallery-carousel/js/Carousel.js
+++ b/src/gallery-carousel/js/Carousel.js
@@ -636,10 +636,11 @@ Y.Carousel = Y.extend(Carousel, Y.Widget, {
         self.fire(BEFORESCROLL_EVENT, { first: first,
                 last: first + numVisible });
         cb.setStyle(attr, offset);
-        first = self.getFirstVisible(); // ask for the "new" first visible
+        self.set("selectedItem", index); // assume this is what the user want
+        first = index; //updating the first element
         self.fire(AFTERSCROLL_EVENT, { first: first,
                 last: first + numVisible });
-        self.set("selectedItem", index); // assume this is what the user want
+       
     },
 
     /**


### PR DESCRIPTION
I have done two changes here:
1. setting the selectedItem before the fire Event as afterScroll Event was getting fired before the scroll completes.
2. Updating the first element which was not getting updated after the scroll.

Please review.

-Sumit
