### PR TITLE
Don't mutate Date objects to get relative time

### DIFF
--- a/src/gallery-torelativetime/js/torelativetime.js
+++ b/src/gallery-torelativetime/js/torelativetime.js
@@ -45,7 +45,9 @@ function toRelativeTime(d,from) {
            delta < 172800 ? strings.day     : '';
 
     if (!time) {
+        d = new Date(d.getTime());
         d.setHours(0,0,0);
+        from = new Date(from.getTime());
         from.setHours(0,0,0);
         delta = Math.round((from.getTime() - d.getTime()) / 86400000);
 


### PR DESCRIPTION
The .setHours() call on the Date objects surprised me when writing an app that uses this module. Making a safe copy of both Date objects if (!time) seems not to pose a performance cost.
