### PR TITLE
TreeView's mapping of node to Widget fixed

### DIFF
--- a/src/gallery-yui-treeview/js/TreeView.js
+++ b/src/gallery-yui-treeview/js/TreeView.js
@@ -266,6 +266,9 @@ Example usage:
             
             treeNode.append(childrenHTML);
             treeWidget.set("populated", true);
+            treeWidget.each(function (child) {
+                child._mapInstance(Y.stamp(child.get('boundingBox')));
+            }, this);
         },
         
        /**

--- a/src/gallery-yui-treeview/js/TreeViewHTMLRenderer.js
+++ b/src/gallery-yui-treeview/js/TreeViewHTMLRenderer.js
@@ -192,8 +192,6 @@ Y.WidgetHTMLRenderer.prototype = {
         }
 
         buffer.push(Handlebars.render(this.BOUNDING_TEMPLATE, context));
-
-        this._mapInstance(context.id);
     },
 
     /**
@@ -272,6 +270,7 @@ Y.WidgetHTMLRenderer.prototype = {
 
         // We need to setup bb/cb references, before bind/sync for backwards compat
         this.syncRenderedBoxes();
+        this._mapInstance(Y.stamp(this.get('boundingBox')));
 
         this._bindUI();
         this.bindUI();


### PR DESCRIPTION
The mapping API changed in YUI 3.6.1, see 8cedb47
TreeView has to wait for Nodes to be instantiated before calling
`Widget._mapInstance`, since the Node's yuid is used for mapping,
not the DOM's id
